### PR TITLE
Validate deadline data

### DIFF
--- a/polly/plugins/maya/publish/submit_deadline.py
+++ b/polly/plugins/maya/publish/submit_deadline.py
@@ -1,41 +1,4 @@
-import os
-import re
-import json
-import shutil
-import getpass
-
-from maya import cmds
-
-from avalon import api
-from avalon.vendor import requests
-
 import pyblish.api
-
-
-def get_vray_extension():
-    """Retrieve the extension which has been set in the VRay settings
-
-    Will return None if the current renderer is not VRay
-
-    Returns:
-        str
-    """
-
-    ext = None
-    if cmds.getAttr("defaultRenderGlobals.currentRenderer") == "vray":
-        # check for vray settings node
-        settings_node = cmds.ls("vraySettings", type="VRaySettingsNode")
-        if not settings_node:
-            raise AttributeError("Could not find a VRay Settings Node, "
-                                 "to ensure the node exists open the "
-                                 "Render Settings window")
-
-        # get the extension
-        image_format = cmds.getAttr("vraySettings.imageFormatStr")
-        if image_format and image_format != ext:
-            ext = "{}".format(image_format)
-
-    return ext
 
 
 class MindbenderSubmitDeadline(pyblish.api.InstancePlugin):
@@ -49,12 +12,21 @@ class MindbenderSubmitDeadline(pyblish.api.InstancePlugin):
     label = "Submit to Deadline"
     order = pyblish.api.IntegratorOrder
     hosts = ["maya"]
-    families = ["colorbleed.renderlayer"]
+    families = ["mindbender.renderlayer"]
 
     def process(self, instance):
+        import os
+        import json
+        import shutil
+        import getpass
+
+        from maya import cmds
+
+        from avalon import api
+        from avalon.vendor import requests
 
         deadline = api.Session.get("AVALON_DEADLINE", None)
-        assert deadline is not None, "Requires AVALON_DEADLINE"
+        assert deadline, "Requires AVALON_DEADLINE"
 
         context = instance.context
         workspace = context.data["workspaceDir"]
@@ -70,13 +42,12 @@ class MindbenderSubmitDeadline(pyblish.api.InstancePlugin):
             pass
 
         # E.g. http://192.168.0.1:8082/api/jobs
-        url = "{}/api/jobs".format(deadline)
+        url = deadline + "/api/jobs"
 
         # Documentation for keys available at:
         # https://docs.thinkboxsoftware.com
         #    /products/deadline/8.0/1_User%20Manual/manual
         #    /manual-submission.html#job-info-file-options
-
         payload = {
             "JobInfo": {
                 # Top-level group name
@@ -99,7 +70,7 @@ class MindbenderSubmitDeadline(pyblish.api.InstancePlugin):
 
                 # Optional, enable double-click to preview rendered
                 # frames from Deadline Monitor
-                "OutputFilename0": self.preview_fname(instance, dirname),
+                "OutputFilename0": self.preview_fname(instance),
             },
             "PluginInfo": {
                 # Input
@@ -149,18 +120,22 @@ class MindbenderSubmitDeadline(pyblish.api.InstancePlugin):
         })
 
         # Include optional render globals
-        payload["JobInfo"].update(instance.data.get("renderGlobals", {}))
+        payload["JobInfo"].update(
+            instance.data.get("renderGlobals", {})
+        )
 
         self.preflight_check(instance)
 
         self.log.info("Submitting..")
-        self.log.info(json.dumps(payload, indent=4, sort_keys=True))
+        self.log.info(json.dumps(
+            payload, indent=4, sort_keys=True)
+        )
 
         response = requests.post(url, json=payload)
 
         if response.ok:
             # Write metadata for publish
-            fname = os.path.join(dirname, "{}.json".format(instance.name))
+            fname = os.path.join(dirname, instance.name + ".json")
             data = {
                 "submission": payload,
                 "session": api.Session,
@@ -182,7 +157,7 @@ class MindbenderSubmitDeadline(pyblish.api.InstancePlugin):
 
             raise Exception(response.text)
 
-    def preview_fname(self, instance, dirname):
+    def preview_fname(self, instance):
         """Return outputted filename with #### for padding
 
         Passing the absolute path to Deadline enables Deadline Monitor
@@ -197,60 +172,29 @@ class MindbenderSubmitDeadline(pyblish.api.InstancePlugin):
 
         """
 
+        from maya import cmds
+
         # We'll need to take tokens into account
-        fname = cmds.renderSettings(firstImageName=True,
-                                    fullPath=True,
-                                    layer=instance.name)[0]
+        fname = cmds.renderSettings(
+            firstImageName=True,
+            fullPath=True,
+            layer=instance.name
+        )[0]
 
-        # outFormatControl:
-        # - 0 is no extension, name.#
-        # - 1 is with extension, name.#.ext
-        # - 2 is use custom extension
-        formatcontol = cmds.getAttr("defaultRenderGlobals.outFormatControl")
-        if formatcontol == 0:
-            raise RuntimeError("Output has no extension")
-
-        # Check the filename formatting from the render settings
-        # Does the output have frames?
-        has_frames = cmds.getAttr("defaultRenderGlobals.animation")
-        if not has_frames:
-            self.log.info("No frames in filename")
-            file_name = os.path.join(dirname, os.path.basename(fname))
-            return file_name
-
-        # Where are the frame put in the filename?
-        frame_before = cmds.getAttr("defaultRenderGlobals.putFrameBeforeExt")
-        # Get the number of digits the padding will get
-        padding_count = cmds.getAttr("defaultRenderGlobals.extensionPadding")
         try:
-            basename = os.path.basename(fname)
-            basename_parts = basename.rsplit(".", 2)
-            # Depending on the where the frame is places, get the right
-            # variables rsplit
-            if frame_before:
-                name, padding, ext = basename_parts
-            else:
-                name, ext, padding = basename_parts
-
-            # check if the extension is correct for vray
-            new_ext = get_vray_extension() or ext
-            new_padding = "#" * padding_count
-            fname = basename.replace(padding, new_padding)
-            if new_ext != ext:
-                fname = fname.replace(ext, new_ext)
-
+            # Assume `c:/some/path/filename.0001.exr`
+            # TODO(marcus): Bulletproof this, the user may have
+            # chosen a different format for the outputted filename.
+            fname, padding, suffix = fname.rsplit(".", 2)
+            fname = ".".join([fname, "#" * len(padding), suffix])
             self.log.info("Assuming renders end up @ %s" % fname)
-
-            file_name = os.path.join(dirname, instance.name, fname)
         except ValueError:
-            file_name = ""
+            fname = ""
             self.log.info("Couldn't figure out where renders go")
 
-        return file_name
+        return fname
 
     def preflight_check(self, instance):
-        """Ensure the startFrame, endFrame and byFrameStep are integers"""
-
         for key in ("startFrame", "endFrame", "byFrameStep"):
             value = instance.data[key]
 

--- a/polly/plugins/maya/publish/submit_deadline.py
+++ b/polly/plugins/maya/publish/submit_deadline.py
@@ -25,8 +25,10 @@ class MindbenderSubmitDeadline(pyblish.api.InstancePlugin):
         from avalon import api
         from avalon.vendor import requests
 
-        assert "AVALON_DEADLINE" in api.Session, ("Environment variable "
-                                                  "missing: 'AVALON_DEADLINE")
+        assert "AVALON_DEADLINE" in api.Session, (
+            "Environment variable missing: 'AVALON_DEADLINE"
+        )
+
         AVALON_DEADLINE = api.Session["AVALON_DEADLINE"]
 
         context = instance.context

--- a/polly/plugins/maya/publish/submit_deadline.py
+++ b/polly/plugins/maya/publish/submit_deadline.py
@@ -53,7 +53,7 @@ class MindbenderSubmitDeadline(pyblish.api.InstancePlugin):
 
     def process(self, instance):
 
-        deadline = api.Session.get("AVALON_DEADLINE", "http://localhost:8082")
+        deadline = api.Session.get("AVALON_DEADLINE", None)
         assert deadline is not None, "Requires AVALON_DEADLINE"
 
         context = instance.context

--- a/polly/plugins/maya/publish/submit_deadline.py
+++ b/polly/plugins/maya/publish/submit_deadline.py
@@ -25,8 +25,9 @@ class MindbenderSubmitDeadline(pyblish.api.InstancePlugin):
         from avalon import api
         from avalon.vendor import requests
 
-        deadline = api.Session.get("AVALON_DEADLINE", None)
-        assert deadline, "Requires AVALON_DEADLINE"
+        assert "AVALON_DEADLINE" in api.Session, ("Environment variable "
+                                                  "missing: 'AVALON_DEADLINE")
+        AVALON_DEADLINE = api.Session["AVALON_DEADLINE"]
 
         context = instance.context
         workspace = context.data["workspaceDir"]
@@ -42,7 +43,7 @@ class MindbenderSubmitDeadline(pyblish.api.InstancePlugin):
             pass
 
         # E.g. http://192.168.0.1:8082/api/jobs
-        url = deadline + "/api/jobs"
+        url = "{}/api/jobs?JobID=%s".format(AVALON_DEADLINE)
 
         # Documentation for keys available at:
         # https://docs.thinkboxsoftware.com

--- a/polly/plugins/publish/validate_deadline_done.py
+++ b/polly/plugins/publish/validate_deadline_done.py
@@ -27,8 +27,7 @@ class ValidateMindbenderDeadlineDone(pyblish.api.InstancePlugin):
         }
 
         assert "AVALON_DEADLINE" in api.Session, ("Environment variable "
-                                                  "missing from current "
-                                                  "session: AVALON_DEADLINE")
+                                                  "missing: 'AVALON_DEADLINE'")
         avalon_deadline = api.Session["AVALON_DEADLINE"]
         url = "{}/api/jobs?JobID=%s".format(avalon_deadline)
 

--- a/polly/plugins/publish/validate_deadline_done.py
+++ b/polly/plugins/publish/validate_deadline_done.py
@@ -27,9 +27,9 @@ class ValidateMindbenderDeadlineDone(pyblish.api.InstancePlugin):
         }
 
         assert "AVALON_DEADLINE" in api.Session, ("Environment variable "
-                                                  "missing: 'AVALON_DEADLINE'")
-        avalon_deadline = api.Session["AVALON_DEADLINE"]
-        url = "{}/api/jobs?JobID=%s".format(avalon_deadline)
+                                                  "missing: 'AVALON_DEADLINE")
+        AVALON_DEADLINE = api.Session["AVALON_DEADLINE"]
+        url = "{}/api/jobs?JobID=%s".format(AVALON_DEADLINE)
 
         for job in instance.data["metadata"]["jobs"]:
             response = requests.get(url % job["_id"])

--- a/polly/plugins/publish/validate_deadline_done.py
+++ b/polly/plugins/publish/validate_deadline_done.py
@@ -26,7 +26,11 @@ class ValidateMindbenderDeadlineDone(pyblish.api.InstancePlugin):
             6: "Pending",
         }
 
-        url = api.Session["AVALON_DEADLINE"] + "/api/jobs?JobID=%s"
+        assert "AVALON_DEADLINE" in api.Session, ("Environment variable "
+                                                  "missing from current "
+                                                  "session: AVALON_DEADLINE")
+        avalon_deadline = api.Session["AVALON_DEADLINE"]
+        url = "{}/api/jobs?JobID=%s".format(avalon_deadline)
 
         for job in instance.data["metadata"]["jobs"]:
             response = requests.get(url % job["_id"])

--- a/polly/plugins/publish/validate_deadline_done.py
+++ b/polly/plugins/publish/validate_deadline_done.py
@@ -38,7 +38,8 @@ class ValidateMindbenderDeadlineDone(pyblish.api.InstancePlugin):
             if response.ok:
                 data = response.json()
                 assert data, ValueError("Can't find information about "
-                                        "this Deadline job")
+                                        "this Deadline job: "
+                                        "{}".format(job["_id"]))
 
                 state = states.get(data[0]["Stat"])
                 if state in (None, "Unknown"):

--- a/polly/plugins/publish/validate_deadline_done.py
+++ b/polly/plugins/publish/validate_deadline_done.py
@@ -32,9 +32,11 @@ class ValidateMindbenderDeadlineDone(pyblish.api.InstancePlugin):
             response = requests.get(url % job["_id"])
 
             if response.ok:
-                data = response.json()[0]
-                state = states.get(data["Stat"])
+                data = response.json()
+                assert data, ValueError("Can't find information about "
+                                        "this Deadline job")
 
+                state = states.get(data[0]["Stat"])
                 if state in (None, "Unknown"):
                     raise Exception("State of this render is unknown")
 


### PR DESCRIPTION
Added check if the `response` actually got data to ensure there is a Deadline job to retrieve information from.
Nicer to get an error message in stead of `list index out of range`.

Added api.Session.get("AVALON_DEADLINE", None)` to counter Key Error from dictionary, assertion will never be evaluated when the key is not available.